### PR TITLE
Update Portainer to 1.20.1

### DIFF
--- a/portainer/Dockerfile
+++ b/portainer/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     && mkdir /opt \
     \
     && curl -L -s \
-        "https://github.com/portainer/portainer/releases/download/1.20.0/portainer-1.20.0-linux-${ARCH}.tar.gz" \
+        "https://github.com/portainer/portainer/releases/download/1.20.1/portainer-1.20.1-linux-${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/
 
 # Build arguments


### PR DESCRIPTION
# Proposed Changes

Updates Portainer to 1.20.1

https://github.com/portainer/portainer/releases/tag/1.20.1
