### PR TITLE
Update Portainter to 1.20.2

### DIFF
--- a/portainer/Dockerfile
+++ b/portainer/Dockerfile
@@ -18,7 +18,7 @@ RUN \
     && mkdir /opt \
     \
     && curl -L -s \
-        "https://github.com/portainer/portainer/releases/download/1.20.1/portainer-1.20.1-linux-${ARCH}.tar.gz" \
+        "https://github.com/portainer/portainer/releases/download/1.20.2/portainer-1.20.2-linux-${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/
 
 # Build arguments


### PR DESCRIPTION
# Proposed Changes

Updates Portainer to the latest version

https://github.com/portainer/portainer/releases/tag/1.20.2

<blockquote><img src="https://avatars1.githubusercontent.com/u/22225832?s=400&v=4" width="48" align="right"><div><img src="https://github.githubassets.com/favicon.ico" height="14"> GitHub</div><div><strong><a href="https://github.com/portainer/portainer">portainer/portainer</a></strong></div><div>Simple management UI for Docker. Contribute to portainer/portainer development by creating an account on GitHub.</div></blockquote>