### PR TITLE
Add info about showing Hass.io managed containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,9 @@ By default all Hass.io managed containers are hidden from Portainer.
 This is recommended since fooling around with Hass.io managed containers
 can easily lead to a broken system.
 
-This is only enforced on the first run. Access to these containers can
-be gained by going into Portainer -> Settings -> Hidden containers.
-Then delete the listed hidden labels (io.hass.type labels).
-**Only do this if you know what you're doing!**
+Access to these containers can be gained by going into Portainer ->
+Settings -> Hidden containers. Then delete the listed hidden labels
+(io.hass.type labels). **Only do this if you know what you're doing!**
 
 ## Changelog & Releases
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ can easily lead to a broken system.
 
 This is only enforced on the first run. Access to these containers can
 be gained by going into Portainer -> Settings -> Hidden containers.
-Then felete the listed hidden labels (io.hass.type labels).
+Then delete the listed hidden labels (io.hass.type labels).
 **Only do this if you know what you're doing!**
 
 ## Changelog & Releases

--- a/README.md
+++ b/README.md
@@ -120,9 +120,6 @@ only exposed to your internal network. USE AT YOUR OWN RISK!_
 
 ## Known issues and limitations
 
-
-### Option: `hide_hassio_containers`
-
 By default all Hass.io managed containers are hidden from Portainer.
 This is recommended since fooling around with Hass.io managed containers
 can easily lead to a broken system.
@@ -130,7 +127,7 @@ can easily lead to a broken system.
 This is only enforced on the first run. Access to these containers can
 be gained by going into Portainer -> Settings -> Hidden containers.
 Then felete the listed hidden labels (io.hass.type labels).
-Only do this if you know what you're doing!
+**Only do this if you know what you're doing!**
 
 ## Changelog & Releases
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,20 @@ authentication by setting it to `true`.
 **Note**: _We STRONGLY suggest, not to use this, even if this add-on is
 only exposed to your internal network. USE AT YOUR OWN RISK!_
 
+## Known issues and limitations
+
+
+### Option: `hide_hassio_containers`
+
+By default all Hass.io managed containers are hidden from Portainer.
+This is recommended since fooling around with Hass.io managed containers
+can easily lead to a broken system.
+
+This is only enforced on the first run. Access to these containers can
+be gained by going into Portainer -> Settings -> Hidden containers.
+Then felete the listed hidden labels (io.hass.type labels).
+Only do this if you know what you're doing!
+
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]


### PR DESCRIPTION
# Proposed Changes

People ask this, so we describe how to do it in the readme.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/