### PR TITLE
Add port mapping for edge agent

### DIFF
--- a/portainer/config.json
+++ b/portainer/config.json
@@ -21,10 +21,12 @@
     "ssl"
   ],
   "ports": {
-    "80/tcp": null
+    "80/tcp": null,
+    "8000/tcp": null
   },
   "ports_description": {
-    "80/tcp": "Web interface (Not required for Hass.io Ingress)"
+    "80/tcp": "Web interface (Not required for Hass.io Ingress)",
+    "8000/tcp": "Edge Agent Api (Enable when managing remote edge agents)"
   },
   "boot": "auto",
   "hassio_api": true,


### PR DESCRIPTION
# Proposed Changes

> Adds an optional port mapping to expose the edge agent port

## Related Issues

> #24 

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/