### PR TITLE
Excluding audio container

### DIFF
--- a/portainer/rootfs/etc/services.d/portainer/run
+++ b/portainer/rootfs/etc/services.d/portainer/run
@@ -25,6 +25,8 @@ if ! bashio::fs.file_exists "/data/hidden"; then
     options+=(--hide-label io.hass.type=addon)
     # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=dns)
+    # shellcheck disable=SC2191
+    options+=(--hide-label io.hass.type=audio)
 
     touch /data/hidden
 fi


### PR DESCRIPTION
# Proposed Changes

Hassio now includes a new hassio_audio container. Adding this to the default exclude list for Portainer.
