### PR TITLE
🔨 Add core to default list of hidden containers

### DIFF
--- a/portainer/rootfs/etc/services.d/portainer/run
+++ b/portainer/rootfs/etc/services.d/portainer/run
@@ -22,6 +22,8 @@ if ! bashio::fs.file_exists "/data/hidden"; then
     # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=homeassistant)
     # shellcheck disable=SC2191
+    options+=(--hide-label io.hass.type=core)
+    # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=addon)
     # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=audio)


### PR DESCRIPTION
# Proposed Changes

> After the hassio/core rename, it looks like the labels changed and the core container is no longer in the list of default hidden labels.

## Related Issues

> N/A