### PR TITLE
🔨 Add base to default list of hidden containers

### DIFF
--- a/portainer/rootfs/etc/services.d/portainer/run
+++ b/portainer/rootfs/etc/services.d/portainer/run
@@ -22,6 +22,8 @@ if ! bashio::fs.file_exists "/data/hidden"; then
     # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=homeassistant)
     # shellcheck disable=SC2191
+    options+=(--hide-label io.hass.type=base)
+    # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=core)
     # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=addon)


### PR DESCRIPTION
# Proposed Changes

I installed this addon to debug high CPU usage on my rpi. I was looking for the deconz addon container and then learned that addon containers (among others) are hidden by default, however I did see the homeassistant container by default. It seems it's type is `base` and that the intention is to hide it by default but it's not done.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/