### PR TITLE
Updated to portainer 2.0.0

### DIFF
--- a/portainer/Dockerfile
+++ b/portainer/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "amd64" ]; then ARCH="amd64"; fi \
     \
     && curl -L -s \
-        "https://github.com/portainer/portainer/releases/download/1.24.0/portainer-1.24.0-linux-${ARCH}.tar.gz" \
+        "https://github.com/portainer/portainer/releases/download/2.0.0/portainer-2.0.0-linux-${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/
 
 # Copy root filesystem


### PR DESCRIPTION
Portainer has release version 2.0.0

# Proposed Changes

Update to the latest release of portainer 2.0.0

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/