### PR TITLE
:hammer: Update run for observer filtering

### DIFF
--- a/portainer/rootfs/etc/services.d/portainer/run
+++ b/portainer/rootfs/etc/services.d/portainer/run
@@ -35,6 +35,8 @@ if ! bashio::fs.file_exists "/data/hidden"; then
     options+=(--hide-label io.hass.type=dns)
     # shellcheck disable=SC2191
     options+=(--hide-label io.hass.type=multicast)
+    # shellcheck disable=SC2191
+    options+=(--hide-label io.hass.type=observer)
 
     touch /data/hidden
 fi


### PR DESCRIPTION
Proposed but not validated change for https://github.com/hassio-addons/addon-portainer/issues/48

# Proposed Changes

> Logically this seems the way to extend the filtering of containers

## Related Issues

> https://github.com/hassio-addons/addon-portainer/issues/48

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/