### PR TITLE
Update Portainer to v 2.5.1

### DIFF
--- a/portainer/Dockerfile
+++ b/portainer/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "amd64" ]; then ARCH="amd64"; fi \
     \
     && curl -L -s \
-        "https://github.com/portainer/portainer/releases/download/1.24.0/portainer-1.24.0-linux-${ARCH}.tar.gz" \
+        "https://github.com/portainer/portainer/releases/download/2.5.1/portainer-2.5.1-linux-${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/
 
 # Copy root filesystem


### PR DESCRIPTION
Updating Portainer to the current version.

# Proposed Changes

updating from v 1.24.0 to v 2.5.1

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
