### PR TITLE
⬆️ Upgrades Portainer to v2.6.2

### DIFF
--- a/portainer/DOCS.md
+++ b/portainer/DOCS.md
@@ -65,16 +65,6 @@ you are troubleshooting.
 An option to set a shared agent secret. Must also be set in the remote agent
 as an Environment variable.
 
-## Known issues and limitations
-
-By default all Home Assistant managed containers are hidden from Portainer.
-This is recommended since fooling around with Home Assistant managed containers
-can easily lead to a broken system.
-
-Access to these containers can be gained by going into Portainer ->
-Settings -> Hidden containers. Then delete the listed hidden labels
-(io.hass.type labels). **Only do this if you know what you're doing!**
-
 ## Changelog & Releases
 
 This repository keeps a change log using [GitHub's releases][releases]

--- a/portainer/Dockerfile
+++ b/portainer/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     && if [ "${BUILD_ARCH}" = "amd64" ]; then ARCH="amd64"; fi \
     \
     && curl -L -s \
-        "https://github.com/portainer/portainer/releases/download/1.24.2/portainer-1.24.2-linux-${ARCH}.tar.gz" \
+        "https://github.com/portainer/portainer/releases/download/2.6.2/portainer-2.6.2-linux-${ARCH}.tar.gz" \
         | tar zxvf - -C /opt/
 
 # Copy root filesystem

--- a/portainer/config.json
+++ b/portainer/config.json
@@ -6,14 +6,11 @@
   "url": "https://github.com/hassio-addons/addon-portainer",
   "advanced": true,
   "ingress": true,
-  "ingress_port": 1337,
   "ingress_stream": true,
   "startup": "services",
   "panel_icon": "mdi:docker",
-  "homeassistant": "0.92.0b2",
   "arch": ["aarch64", "amd64", "armhf", "armv7"],
   "init": false,
-  "map": ["ssl"],
   "ports": {
     "8000/tcp": null
   },

--- a/portainer/rootfs/etc/services.d/portainer/run
+++ b/portainer/rootfs/etc/services.d/portainer/run
@@ -9,37 +9,8 @@ export AGENT_SECRET
 bashio::log.info 'Starting Portainer...'
 
 options+=(--data /data)
-options+=(--bind 0.0.0.0:1337)
-options+=(--no-auth)
-options+=(--template-file /opt/portainer/templates.json)
-options+=(--no-analytics)
+options+=(--bind 0.0.0.0:8099)
 options+=(--host unix:///var/run/docker.sock)
-
-# Hide Hassio containers by default, but only eforce on first run
-if ! bashio::fs.file_exists "/data/hidden"; then
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=supervisor)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=homeassistant)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=base)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=core)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=addon)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=audio)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=cli)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=dns)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=multicast)
-    # shellcheck disable=SC2191
-    options+=(--hide-label io.hass.type=observer)
-
-    touch /data/hidden
-fi
 
 # Export agent secret, if defined
 if bashio::config.has_value 'agent_secret' ; then


### PR DESCRIPTION
# Proposed Changes

- Upgrades Portainer to the v2.x branch
- Cleans up the matching configuration as well
- No longer hide Home Assistant containers to reduce questions/support, it doesn't seem to work with 2.x really well either. The add-on is marked advanced.
